### PR TITLE
[ECP-9167] Bump the version of module-payment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "version": "100.0.0",
     "type": "magento2-module",
     "require": {
-        "adyen/module-payment": "9.2.0",
+        "adyen/module-payment": "^9.5.0",
         "hyva-themes/magento2-default-theme": "^1.3"
     },
     "autoload": {


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The version of module-payment in composer.json is hardcoded to 9.2.0. It should be ^9.5.0.

<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
