### PR TITLE
feat: disable place order button for adyen_cc

### DIFF
--- a/Magewire/Payment/Method/CreditCard.php
+++ b/Magewire/Payment/Method/CreditCard.php
@@ -9,7 +9,7 @@ use Adyen\Hyva\Model\CreditCard\BrandsManager;
 use Adyen\Hyva\Model\CreditCard\InstallmentsManager;
 use Hyva\Checkout\Model\Magewire\Component\Evaluation\EvaluationResult;
 use Hyva\Checkout\Model\Magewire\Component\EvaluationResultFactory;
-
+use Magento\Checkout\Model\Session as SessionCheckout;
 class CreditCard extends AdyenPaymentComponent
 {
     const METHOD_CC = 'adyen_cc';
@@ -19,6 +19,7 @@ class CreditCard extends AdyenPaymentComponent
         private readonly Context $context,
         private readonly BrandsManager $brandsManager,
         private readonly InstallmentsManager $installmentsManager,
+        private readonly SessionCheckout $sessionCheckout
 
     ) {
         parent::__construct($this->context);
@@ -37,7 +38,10 @@ class CreditCard extends AdyenPaymentComponent
      */
     public function evaluateCompletion(EvaluationResultFactory $resultFactory): EvaluationResult
     {
-        return $resultFactory->createSuccess();
+        $payment = $this->sessionCheckout->getQuote()->getPayment();
+        return $payment->getMethod() === 'adyen_cc' && !$payment->getAdditionalData()
+            ? $resultFactory->createBlocking()
+            : $resultFactory->createSuccess();
     }
 
     public function refreshProperties(): void


### PR DESCRIPTION
Disable button as default. Button gets enabled after all cc form fields are filled out correctly.

Closes #55

## Summary
When choosing cc as payment method the place order button should be disabled, until all cc form fields are filled correctly.
This PR changes method evaluateCompletion() in the Magewire CreditCard component to disable the button.

The button is enabled after all fields in the cc form are valid.

## Tested scenarios
Tested on Magento 2.4.6-p7 with Hyvä Checkout 1.1.24 and Adyen Hyvä Module 1.0.0
Tested as guest and logged in customer
Tested only with Adyen Test Plattform

**Fixed issue**:  #-55
