### PR TITLE
Issue Preventing Checkout with Configurable Products in Low Stock

### DIFF
--- a/Model/CompositeConfigProvider.php
+++ b/Model/CompositeConfigProvider.php
@@ -7,20 +7,24 @@ namespace Adyen\Hyva\Model;
 use Magento\Checkout\Model\ConfigProviderInterface;
 class CompositeConfigProvider implements ConfigProviderInterface
 {
-    private $configProviders;
-
+    /**
+     * @param array $configProviders
+     */
     public function __construct(
-        array $configProviders
-    ) {
-        $this->configProviders = $configProviders;
-    }
+        private readonly array $configProviders
+    ) { }
 
-    public function getConfig()
+    /**
+     * @return array
+     */
+    public function getConfig(): array
     {
         $config = [];
+
         foreach ($this->configProviders as $configProvider) {
             $config = array_merge_recursive($config, $configProvider->getConfig());
         }
+
         return $config;
     }
 }

--- a/Model/CompositeConfigProvider.php
+++ b/Model/CompositeConfigProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adyen\Hyva\Model;
+
+use Magento\Checkout\Model\ConfigProviderInterface;
+class CompositeConfigProvider implements ConfigProviderInterface
+{
+    private $configProviders;
+
+    public function __construct(
+        array $configProviders
+    ) {
+        $this->configProviders = $configProviders;
+    }
+
+    public function getConfig()
+    {
+        $config = [];
+        foreach ($this->configProviders as $configProvider) {
+            $config = array_merge_recursive($config, $configProvider->getConfig());
+        }
+        return $config;
+    }
+}

--- a/Model/Configuration.php
+++ b/Model/Configuration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Adyen\Hyva\Model;
 
 use Exception;
-use Magento\Checkout\Model\CompositeConfigProvider;
 use Magento\Framework\DataObject;
 use Magento\Framework\DataObjectFactory;
 use Psr\Log\LoggerInterface;
@@ -16,8 +15,8 @@ class Configuration
 
     public function __construct(
         CompositeConfigProvider $configProvider,
-        DataObjectFactory $dataObjectFactory,
-        LoggerInterface $logger
+        DataObjectFactory       $dataObjectFactory,
+        LoggerInterface         $logger
     ) {
         try {
             if (isset($configProvider->getConfig()['payment'])) {

--- a/Test/Unit/Model/CompositeConfigProviderTest.php
+++ b/Test/Unit/Model/CompositeConfigProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Hyva\Test\Unit\Model;
+
+use Adyen\Hyva\Model\CompositeConfigProvider;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Checkout\Model\ConfigProviderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CompositeConfigProviderTest extends AbstractAdyenTestCase
+{
+    protected ?CompositeConfigProvider $compositeConfigProvider;
+    protected MockObject|array $configProvidersMock;
+    protected MockObject|ConfigProviderInterface $singleConfigProviderMock;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->singleConfigProviderMock = $this->createMock(ConfigProviderInterface::class);
+        $this->configProvidersMock[] = $this->singleConfigProviderMock;
+
+        $this->compositeConfigProvider = new CompositeConfigProvider($this->configProvidersMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->compositeConfigProvider = null;
+    }
+
+    /**
+     * Test case to assert all available config values provided through di.xml
+     *
+     * @return void
+     */
+    public function testGetConfig()
+    {
+        $configMock = [
+            'config1' => 'value1',
+            'config2' => 'value2'
+        ];
+
+        $this->singleConfigProviderMock->expects($this->once())
+            ->method('getConfig')
+            ->willReturn($configMock);
+
+        $result = $this->compositeConfigProvider->getConfig();
+        $this->assertEquals($configMock, $result);
+    }
+}

--- a/Test/Unit/Model/ConfigurationTest.php
+++ b/Test/Unit/Model/ConfigurationTest.php
@@ -2,19 +2,19 @@
 
 namespace Adyen\Hyva\Test\Unit\Model;
 
+use Adyen\Hyva\Model\CompositeConfigProvider;
 use Adyen\Hyva\Model\Configuration;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
-use Magento\Checkout\Model\CompositeConfigProvider;
 use Magento\Framework\DataObjectFactory;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ConfigurationTest extends AbstractAdyenTestCase
 {
-    private Configuration $configuration;
-    private CompositeConfigProvider|MockObject $configProvider;
-    private DataObjectFactory|MockObject $dataObjectFactory;
-    private LoggerInterface|MockObject $logger;
+    protected Configuration $configuration;
+    protected CompositeConfigProvider|MockObject $configProvider;
+    protected DataObjectFactory|MockObject $dataObjectFactory;
+    protected LoggerInterface|MockObject $logger;
 
     protected function setUp(): void
     {
@@ -26,13 +26,9 @@ class ConfigurationTest extends AbstractAdyenTestCase
                 ]
         ];
 
-        $this->configProvider = $this->getMockBuilder(CompositeConfigProvider::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->configProvider = $this->createMock(CompositeConfigProvider::class);
         $this->dataObjectFactory = $this->createGeneratedMock(DataObjectFactory::class, ['create']);
-        $this->logger = $this->getMockBuilder(LoggerInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         $this->configProvider->expects($this->exactly(2))
             ->method('getConfig')
@@ -74,6 +70,7 @@ class ConfigurationTest extends AbstractAdyenTestCase
         $jsonValue = $this->configuration->getJsonValue('nonexistent/path');
         $this->assertSame('null', $jsonValue);
     }
+
     public function testIsCCEnableStoreDetails(): void
     {
         $result = $this->configuration->isCCEnableStoreDetails(false);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -42,4 +42,21 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Adyen\Hyva\Model\CompositeConfigProvider">
+        <arguments>
+            <argument name="configProviders" xsi:type="array">
+                <item name="ccform" xsi:type="object">Magento\Payment\Model\CcGenericConfigProvider</item>
+                <item name="cc_card_config_provider" xsi:type="object">Magento\Payment\Model\CcConfigProvider</item>
+                <item name="tax_config_provider" xsi:type="object">Magento\Tax\Model\TaxConfigProvider</item>
+                <item name="vault_config_provider" xsi:type="object">Magento\Vault\Model\Ui\VaultConfigProvider</item>
+                <item name="vault_cards_config_provider" xsi:type="object">Magento\Vault\Model\Ui\TokensConfigProvider</item>
+                <item name="adyen_generic_config_provider" xsi:type="object">Adyen\Payment\Model\Ui\AdyenGenericConfigProvider</item>
+                <item name="adyen_cc_config_provider" xsi:type="object">Adyen\Payment\Model\Ui\AdyenCcConfigProvider</item>
+                <item name="adyen_pm_config_provider" xsi:type="object">Adyen\Payment\Model\Ui\AdyenPmConfigProvider</item>
+                <item name="adyen_pos_cloud_config_provider" xsi:type="object">Adyen\Payment\Model\Ui\AdyenPosCloudConfigProvider</item>
+                <item name="adyen_giftcard_config_provider" xsi:type="object">Adyen\Payment\Model\Ui\AdyenGiftcardConfigProvider</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Issue happens when One Product is in Stock. No order can be placed. After investigating the issue, it's observed that no problems occur with MSI + Adyen or with Hyva theme + MSI. However, the issue arises when the compatibility module is involved. Specifically, when attempting to add a configurable product with limited stock (e.g., 2 items), the shipping methods do not appear on the checkout page. Interestingly, if the pre-selected shipping method is not changed, the issue does not occur.
In the compatibility module, there are two calls to `CartItemPersister`, which processes `BuyRequestData` differently each time:

**First Call:** `BuyRequestData` is returned as a float (indicating, possibly, a single unit or specific quantity).
**Second Call:** `BuyRequestData` is returned as an object (indicating a detailed configuration request, such as specific product options or custom data).
When `BuyRequestData` is treated as an object in the second request, Magento’s `Quote.php` interprets this as a full update request for the cart. It tries to add more of the product to the cart, potentially exceeding the available stock, thus triggering an out-of-stock exception.

Since the configuration is only needed to populate information in the payment block, we might avoid the issue by fetching only the specific configuration data required for that payment block, without altering the existing cart item quantities.

With the proposed solution, The `CompositeConfigProvider` consolidates configurations from various ConfigProviderInterface implementations. By including only the necessary configuration providers, we avoid any unnecessary processing that might interfere with cart items or stock levels.

## Tested scenarios
<!-- Description of tested scenarios -->
It's possible to change the country
It's possible to select a shipping method
Successful Payment with the limited quantity in stock for configurable object

Fixes #59 