### PR TITLE
Card type should be called scheme

### DIFF
--- a/Model/PaymentMethod/Filter/AdyenConfigured.php
+++ b/Model/PaymentMethod/Filter/AdyenConfigured.php
@@ -74,7 +74,7 @@ class AdyenConfigured implements FilterInterface
     private function collectMethodCodeWithoutPrefix($methodCode): string
     {
         if ($methodCode == CreditCard::METHOD_CC) {
-            return 'card';
+            return 'scheme';
         }
 
         return substr(

--- a/Test/Unit/Model/CreditCard/BrandsManagerTest.php
+++ b/Test/Unit/Model/CreditCard/BrandsManagerTest.php
@@ -74,11 +74,11 @@ class BrandsManagerTest extends \PHPUnit\Framework\TestCase
                 'paymentMethodsResponse' => [
                     'paymentMethodsResponse' => [
                         'paymentMethods' => [
-                            'card' => [
+                            [
                                 'type' => 'scheme',
                                 'brands' => ['mc', 'visa'],
                             ],
-                            'somethings_irrelevant' => [
+                            [
                                 'type' => 'somethings_irrelevant',
                                 'brands' => [],
                             ],

--- a/Test/Unit/Model/PaymentMethod/Filter/AdyenConfiguredTest.php
+++ b/Test/Unit/Model/PaymentMethod/Filter/AdyenConfiguredTest.php
@@ -45,7 +45,7 @@ class AdyenConfiguredTest extends TestCase
         ];
 
         $paymentMethods = [
-            'card' => [],
+            'scheme' => [],
             'googlepay' => [],
             'bmcm' => []
         ];

--- a/Test/Unit/Model/PaymentMethod/PaymentMethodsTest.php
+++ b/Test/Unit/Model/PaymentMethod/PaymentMethodsTest.php
@@ -86,11 +86,11 @@ class PaymentMethodsTest extends \PHPUnit\Framework\TestCase
                 'paymentMethodsResponse' => [
                     'paymentMethodsResponse' => [
                         'paymentMethods' => [
-                            'card' => [
+                            [
                                 'type' => 'scheme',
                                 'brands' => ['mc', 'visa'],
                             ],
-                            'somethings_else' => [
+                            [
                                 'type' => 'something_else',
                                 'brands' => [],
                             ],

--- a/view/frontend/templates/payment/method-renderer/adyen-cc-method.phtml
+++ b/view/frontend/templates/payment/method-renderer/adyen-cc-method.phtml
@@ -66,7 +66,7 @@ use Adyen\Hyva\Magewire\Payment\Method\CreditCard;
                                     creditCardHandler.setCreditCardType(creditCardHandler.getCcCodeByAltCode(state.brand));
                                 },
                                 name: '<?= $escaper->escapeJs($magewire->getConfiguration()->getValue('adyenCc/title')) ?>',
-                                type: "card",
+                                type: "scheme",
                                 code: methodCode
                             };
 


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
The credit-card payment method did not show up for me. It seems like that is because the response from /paymentMethods gives the cards with the 'scheme' type payment method.
```
{
  "body": {
    "paymentMethods": [
      {
        "brands": [
          "mc",
          "visa",
          "amex"
        ],
        "name": "Credit en Debit card",
        "type": "scheme"
      }
    ]
  }
}
```
 It seems that the adyen-magento2 module has a map for this case [here](https://github.com/Adyen/adyen-magento2/blob/3ee5a3e32ed8b6bdba5869b46db5944cfd01b208/Helper/PaymentMethodsFilter.php#L24).

I also noticed that the test had a key for `paymentMethods` return. But in my case it did not return the  `paymentMethods` with a key...

## Tested scenarios
<!-- Description of tested scenarios -->
Open checkout and see if the cards payment method shows up.
It didn't before now it does.

Fixes #66 

## Versions used

- Magento 2.4.7-p3
- adyen/module-hyva-checkout 1.2.1
- adyen/module-payment 9.9.1
- adyen/php-api-library 19.1.0