### PR TITLE
Add visual loading.. spinner to place order

### DIFF
--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -354,10 +354,10 @@ $billingAddress = $block->getQuoteBillingAddress();
                 .then(() => {
                     let paymentStatus = JSON.parse(wire.get('paymentStatus'));
                     self.handleAdyenResult(paymentStatus);
-                }).catch(() => {
-                    console.log('Error occurred during order placement')
-                }).finish(() =>  {
                     window.dispatchEvent(new Event('magewire:loader:done'));
+                }).catch(() => {
+                    window.dispatchEvent(new Event('magewire:loader:done'));
+                    console.log('Error occurred during order placement');
                 });
         }
 

--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -357,7 +357,7 @@ $billingAddress = $block->getQuoteBillingAddress();
                 }).catch(() => {
                     console.log('Error occurred during order placement')
                 }).finish(() =>  {
-                    window.dispatchEvent(new Event('magewire:loader:done')
+                    window.dispatchEvent(new Event('magewire:loader:done'));
                 });
         }
 

--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -342,6 +342,7 @@ $billingAddress = $block->getQuoteBillingAddress();
         }
 
         placeOrder(data, publicHash = null) {
+            window.dispatchEvent(new Event('magewire:loader:start'));
             let self = this;
             let wire = self.wire;
 
@@ -355,6 +356,8 @@ $billingAddress = $block->getQuoteBillingAddress();
                     self.handleAdyenResult(paymentStatus);
                 }).catch(() => {
                     console.log('Error occurred during order placement')
+                }).finish(() =>  {
+                    window.dispatchEvent(new Event('magewire:loader:done')
                 });
         }
 


### PR DESCRIPTION
## Summary
It can take some time to process the place order wire, all the while the user does not know that a process is running.
This will add a loading spinner for the place order event.

**Tested scenarios**
- Card payments w/wo 3DS2 happy/unhappy flows
- Klarna redirect with success and cancellation flows
- Google Pay wallet payment