### PR TITLE
Update sorting payment method feature

### DIFF
--- a/Plugin/ViewModel/Checkout/Payment/MethodList.php
+++ b/Plugin/ViewModel/Checkout/Payment/MethodList.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Adyen\Hyva\Plugin\ViewModel\Checkout\Payment;
+
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Adyen\Payment\Helper\PaymentMethodsFilter;
+use Hyva\Checkout\ViewModel\Checkout\Payment\MethodList as HyvaMethodList;
+
+class MethodList
+{
+    private $helper;
+
+    private $checkoutSession;
+
+    public function __construct(
+        CheckoutSession $checkoutSession,
+        PaymentMethodsFilter $helper
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->helper = $helper;
+    }
+
+    public function afterGetList(HyvaMethodList $subject, $result)
+    {
+        list($result, $adyenPaymentMethodsResponse) = $this->helper->sortAndFilterPaymentMethods($result, $this->checkoutSession->getQuote());
+        return $result;
+    }
+}

--- a/Plugin/ViewModel/Checkout/Payment/MethodList.php
+++ b/Plugin/ViewModel/Checkout/Payment/MethodList.php
@@ -5,24 +5,35 @@ namespace Adyen\Hyva\Plugin\ViewModel\Checkout\Payment;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Adyen\Payment\Helper\PaymentMethodsFilter;
 use Hyva\Checkout\ViewModel\Checkout\Payment\MethodList as HyvaMethodList;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class MethodList
 {
-    private $helper;
-
-    private $checkoutSession;
-
+    /**
+     * @param CheckoutSession $checkoutSession
+     * @param PaymentMethodsFilter $paymentMethodsFilterHelper
+     */
     public function __construct(
-        CheckoutSession $checkoutSession,
-        PaymentMethodsFilter $helper
-    ) {
-        $this->checkoutSession = $checkoutSession;
-        $this->helper = $helper;
-    }
+        private readonly CheckoutSession $checkoutSession,
+        private readonly PaymentMethodsFilter $paymentMethodsFilterHelper
+    ) { }
 
-    public function afterGetList(HyvaMethodList $subject, $result)
+    /**
+     * This plugin changes the sorting order of the payment methods on the checkout
+     * based on the sorting order of the payment methods on Adyen Customer Area.
+     *
+     * @param HyvaMethodList $subject
+     * @param $result
+     * @return array
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function afterGetList(HyvaMethodList $subject, $result): array
     {
-        list($result, $adyenPaymentMethodsResponse) = $this->helper->sortAndFilterPaymentMethods($result, $this->checkoutSession->getQuote());
-        return $result;
+        list($sortedMagentoPaymentMethods, $adyenPaymentMethodsResponse) = $this->paymentMethodsFilterHelper
+            ->sortAndFilterPaymentMethods($result, $this->checkoutSession->getQuote());
+
+        return $sortedMagentoPaymentMethods ?? $result;
     }
 }

--- a/Test/Unit/Plugin/ViewModel/Checkout/Component/Payment/MethodListTest.php
+++ b/Test/Unit/Plugin/ViewModel/Checkout/Component/Payment/MethodListTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Adyen\Hyva\Test\Unit\Plugin\ViewModel\Checkout\Component\Payment;
+
+use Adyen\Hyva\Plugin\ViewModel\Checkout\Payment\MethodList;
+use Adyen\Payment\Helper\PaymentMethodsFilter;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Hyva\Checkout\ViewModel\Checkout\Payment\MethodList as HyvaMethodList;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Payment\Model\Method\Adapter;
+use Magento\Quote\Api\Data\CartInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MethodListTest extends AbstractAdyenTestCase
+{
+    protected ?MethodList $methodList;
+    protected CheckoutSession|MockObject $checkoutSessionMock;
+    protected PaymentMethodsFilter|MockObject $paymentMethodsFilterHelperMock;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->checkoutSessionMock = $this->createMock(CheckoutSession::class);
+        $this->paymentMethodsFilterHelperMock = $this->createMock(PaymentMethodsFilter::class);
+
+        $this->methodList = new MethodList(
+            $this->checkoutSessionMock,
+            $this->paymentMethodsFilterHelperMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $this->methodList = null;
+    }
+
+    /**
+     * @return void
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function testAfterGetListSuccess()
+    {
+        $subjectMock = $this->createMock(HyvaMethodList::class);
+        $resultMock = [
+            0 => [$this->createMock(Adapter::class)],
+            1 => []
+        ];
+
+        $cartMock = $this->createMock(CartInterface::class);
+        $this->checkoutSessionMock->expects($this->once())
+            ->method('getQuote')
+            ->willReturn($cartMock);
+
+        $this->paymentMethodsFilterHelperMock->expects($this->once())
+            ->method('sortAndFilterPaymentMethods')
+            ->with($resultMock, $cartMock)
+            ->willReturn($resultMock);
+
+        $methodResult = $this->methodList->afterGetList($subjectMock, $resultMock);
+        $this->assertEquals($resultMock[0], $methodResult);
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -7,4 +7,8 @@
     <type name="Hyva\Checkout\Model\Magewire\Component\Resolver\Checkout">
         <plugin name="adyen.hyva.resolver.checkout" type="Adyen\Hyva\Plugin\HyvaCheckout\Model\Magewire\Component\Resolver\Checkout" />
     </type>
+    <type name="Hyva\Checkout\ViewModel\Checkout\Payment\MethodList">
+        <plugin name="sorting_payment_method"
+                type="Adyen\Hyva\Plugin\ViewModel\Checkout\Payment\MethodList" sortOrder="10" />
+    </type>
 </config>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Currently, Hyvä compatibility module doesn't reflect the sorting order of the payment methods set on Adyen Customer Area. This PR implements the helper function to sort them accordingly.


## Tested scenarios
<!-- Description of tested scenarios -->
- Customer Area payment method sorting order changes

Fixes #72 