### PR TITLE
[ECP-9547] Adding BrandCodeDataAssigner to the other Klarna PM variants

### DIFF
--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -14,6 +14,12 @@
     <event name="payment_method_assign_data_adyen_klarna">
         <observer name="adyen_hyva_klarna_gateway_data_assign" instance="Adyen\Hyva\Observer\BrandCodeDataAssigner" />
     </event>
+    <event name="payment_method_assign_data_adyen_klarna_paynow">
+        <observer name="adyen_hyva_klarna_paynow_gateway_data_assign" instance="Adyen\Hyva\Observer\BrandCodeDataAssigner" />
+    </event>
+    <event name="payment_method_assign_data_adyen_klarna_account">
+        <observer name="adyen_hyva_klarna_account_gateway_data_assign" instance="Adyen\Hyva\Observer\BrandCodeDataAssigner" />
+    </event>
     <event name="payment_method_assign_data_adyen_facilypay_3x">
         <observer name="adyen_hyva_facilypay_3x_gateway_data_assign" instance="Adyen\Hyva\Observer\BrandCodeDataAssigner" />
     </event>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
It seems that one cannot use Klarna PayNow as a payment method. The issue is caused by missing data (invoiceLines) required for the payment to be processed.

This is because in Hyva we have to add BRAND_CODE to additionalData via BrandCodeDataAssigner observer. This Observer is currently only set for Klarna and needs to done for the Klarna Pay Now and Klarna Pay Later.
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
#71 