### PR TITLE
Update remove page layout

### DIFF
--- a/view/frontend/layout/hyva_checkout_index_index.xml
+++ b/view/frontend/layout/hyva_checkout_index_index.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      layout="checkout"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="Adyen_Payment::css/adyen.css" />


### PR DESCRIPTION
Remove unnecessary setting/overriding of the page layout in the checkout

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
The layout XML explicitly sets the page layout to "checkout". This is unnecessary and should be left to the integrator or custom theme. Because of this attribute, an override on Adyen_Hyva is required while the checkout page layout should not be part of scope of the payment method provider.


## Tested scenarios
Customised checkout page layout in the Hyva_Checkout module namespace where it was changed to "1-column". Now it remains "1-column" and isn't overridden by this module.

**Fixed issue**: https://github.com/Adyen/adyen-magento2-hyva/issues/81
