### PR TITLE
[ECP-9572] Implement agreement acceptor for Terms & Conditions

### DIFF
--- a/Magewire/Payment/Method/AdyenPaymentComponent.php
+++ b/Magewire/Payment/Method/AdyenPaymentComponent.php
@@ -20,6 +20,7 @@ use Hyva\Checkout\Model\Magewire\Component\EvaluationResultFactory;
 use Magento\Checkout\Api\GuestPaymentInformationManagementInterface;
 use Magento\Checkout\Api\PaymentInformationManagementInterface;
 use Magento\Checkout\Model\Session;
+use Magento\Quote\Api\Data\PaymentExtensionFactory;
 use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
 use Magewirephp\Magewire\Component;
 use Psr\Log\LoggerInterface;
@@ -61,7 +62,8 @@ abstract class AdyenPaymentComponent extends Component implements EvaluationInte
     const FRONTENDTYPE_HYVA = 'hyva';
 
     public function __construct(
-        private readonly Context $context
+        private readonly Context $context,
+        private readonly PaymentExtensionFactory $paymentExtensionFactory
     ) {
         $this->checkoutStateDataValidator = $context->getCheckoutStateDataValidator();
         $this->configuration = $context->getConfiguration();
@@ -103,6 +105,14 @@ abstract class AdyenPaymentComponent extends Component implements EvaluationInte
             $quoteId = $this->session->getQuoteId();
             $payment = $this->session->getQuote()->getPayment();
             $payment->setAdditionalInformation(HeaderDataBuilder::FRONTENDTYPE, self::FRONTENDTYPE_HYVA);
+
+            if (!empty($data['extension_attributes']['agreement_ids'])) {
+                $paymentExtension = $this->paymentExtensionFactory->create();
+                $paymentExtension->setAgreementIds($data['extension_attributes']['agreement_ids']);
+
+                $payment->setExtensionAttributes($paymentExtension);
+            }
+
             $stateDataReceived = $this->collectValidatedStateData($data);
             //Temporary (per request) storage of state data
             $this->stateData->setStateData($stateDataReceived, (int) $quoteId);

--- a/Magewire/Payment/Method/CreditCard.php
+++ b/Magewire/Payment/Method/CreditCard.php
@@ -9,6 +9,7 @@ use Adyen\Hyva\Model\CreditCard\BrandsManager;
 use Adyen\Hyva\Model\CreditCard\InstallmentsManager;
 use Hyva\Checkout\Model\Magewire\Component\Evaluation\EvaluationResult;
 use Hyva\Checkout\Model\Magewire\Component\EvaluationResultFactory;
+use Magento\Quote\Api\Data\PaymentExtensionFactory;
 
 class CreditCard extends AdyenPaymentComponent
 {
@@ -18,9 +19,13 @@ class CreditCard extends AdyenPaymentComponent
     public function __construct(
         private readonly Context $context,
         private readonly BrandsManager $brandsManager,
-        private readonly InstallmentsManager $installmentsManager
+        private readonly InstallmentsManager $installmentsManager,
+        private readonly PaymentExtensionFactory $paymentExtensionFactory
     ) {
-        parent::__construct($this->context);
+        parent::__construct(
+            $this->context,
+            $this->paymentExtensionFactory
+        );
     }
 
     /**

--- a/Magewire/Payment/Method/StoredCards.php
+++ b/Magewire/Payment/Method/StoredCards.php
@@ -10,6 +10,7 @@ use Adyen\Hyva\Model\CreditCard\InstallmentsManager;
 use Exception;
 use Hyva\Checkout\Model\Magewire\Component\Evaluation\EvaluationResult;
 use Hyva\Checkout\Model\Magewire\Component\EvaluationResultFactory;
+use Magento\Quote\Api\Data\PaymentExtensionFactory;
 
 class StoredCards extends AdyenPaymentComponent
 {
@@ -18,9 +19,13 @@ class StoredCards extends AdyenPaymentComponent
     public function __construct(
         private readonly Context $context,
         private readonly InstallmentsManager $installmentsManager,
+        private readonly PaymentExtensionFactory $paymentExtensionFactory
 
     ) {
-        parent::__construct($this->context);
+        parent::__construct(
+            $this->context,
+            $this->paymentExtensionFactory
+        );
     }
 
     /**

--- a/Test/Unit/Magewire/Payment/Method/CreditCardTest.php
+++ b/Test/Unit/Magewire/Payment/Method/CreditCardTest.php
@@ -17,7 +17,7 @@ use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Checkout\Api\GuestPaymentInformationManagementInterface;
 use Magento\Checkout\Api\PaymentInformationManagementInterface;
 use Magento\Checkout\Model\Session;
-use Magento\Quote\Api\Data\PaymentExtension;
+use Magento\Quote\Api\Data\PaymentExtensionInterface;
 use Magento\Quote\Api\Data\PaymentExtensionFactory;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
@@ -101,9 +101,10 @@ class CreditCardTest extends AbstractAdyenTestCase
             PaymentExtensionFactory::class,
             ['create']
         );
-        $this->paymentExtensionMock = $this->getMockBuilder(PaymentExtension::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->paymentExtensionMock = $this->createGeneratedMock(
+            PaymentExtensionInterface::class,
+            ['setAgreementIds']
+        );
 
         $this->context = new Context(
             $this->checkoutStateDataValidator,

--- a/Test/Unit/Magewire/Payment/Method/StoredCardsTest.php
+++ b/Test/Unit/Magewire/Payment/Method/StoredCardsTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Adyen\Hyva\Test\Unit\Magewire\Payment\Method;
+
+use Adyen\Hyva\Api\ProcessingMetadataInterface;
+use Adyen\Hyva\Magewire\Payment\Method\CreditCard;
+use Adyen\Hyva\Magewire\Payment\Method\StoredCards;
+use Adyen\Hyva\Model\Component\Payment\Context;
+use Adyen\Hyva\Model\CreditCard\InstallmentsManager;
+use Adyen\Payment\Api\AdyenOrderPaymentStatusInterface;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Hyva\Checkout\Model\Magewire\Component\Evaluation\Success;
+use Hyva\Checkout\Model\Magewire\Component\EvaluationResultFactory;
+use Magento\Checkout\Api\PaymentInformationManagementInterface;
+use Magento\Checkout\Model\Session;
+use Magento\Quote\Api\Data\PaymentExtensionFactory;
+use Magento\Quote\Api\Data\PaymentExtensionInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class StoredCardsTest extends AbstractAdyenTestCase
+{
+    protected Context|MockObject $contextMock;
+    protected InstallmentsManager|MockObject $installmentsManagerMock;
+    protected PaymentExtensionFactory|MockObject $paymentExtensionFactoryMock;
+    protected PaymentExtensionInterface|MockObject $paymentExtensionMock;
+    protected Session|MockObject $sessionMock;
+    protected Quote|MockObject $quoteMock;
+    protected Payment|MockObject $paymentMock;
+    protected PaymentInformationManagementInterface|MockObject $paymentInformationManagementMock;
+    protected AdyenOrderPaymentStatusInterface|MockObject $adyenOrderPaymentStatusMock;
+    protected ?StoredCards $storedCards;
+
+    public function setUp(): void
+    {
+        $this->installmentsManagerMock = $this->createMock(InstallmentsManager::class);
+        $this->paymentExtensionFactoryMock = $this->createGeneratedMock(
+            PaymentExtensionFactory::class,
+            ['create']
+        );
+        $this->paymentExtensionMock = $this->createGeneratedMock(
+            PaymentExtensionInterface::class,
+            ['setAgreementIds']
+        );
+        $this->sessionMock = $this->createMock(Session::class);
+        $this->quoteMock = $this->createMock(Quote::class);
+        $this->paymentMock = $this->createMock(Payment::class);
+        $this->paymentInformationManagementMock =
+            $this->createMock(PaymentInformationManagementInterface::class);
+        $this->adyenOrderPaymentStatusMock =
+            $this->createMock(AdyenOrderPaymentStatusInterface::class);
+
+        $this->contextMock = $this->createMock(Context::class);
+        $this->contextMock->method('getSession')->willReturn($this->sessionMock);
+        $this->contextMock->method('getPaymentInformationManagement')
+            ->willReturn($this->paymentInformationManagementMock);
+        $this->contextMock->method('getAdyenOrderPaymentStatus')
+            ->willReturn($this->adyenOrderPaymentStatusMock);
+
+        $this->storedCards = new StoredCards(
+            $this->contextMock,
+            $this->installmentsManagerMock,
+            $this->paymentExtensionFactoryMock
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->storedCards = null;
+    }
+
+    public function testGetMethodCode()
+    {
+        $this->assertEquals(CreditCard::METHOD_CC, $this->storedCards->getMethodCode());
+    }
+
+    public function testEvaluateComplete()
+    {
+        $successMock = $this->createMock(Success::class);
+        $resultFactoryMock = $this->createMock(EvaluationResultFactory::class);
+        $resultFactoryMock->expects($this->once())
+            ->method('createSuccess')
+            ->willReturn($successMock);
+
+        $this->assertInstanceOf(
+            Success::class,
+            $this->storedCards->evaluateCompletion($resultFactoryMock)
+        );
+    }
+
+    public function testGetFormattedInstallments()
+    {
+        $mockInstalments = '{"visa":[1,2,3]}';
+
+        $this->installmentsManagerMock->expects($this->once())
+            ->method('getFormattedInstallments')
+            ->willReturn($mockInstalments);
+
+        $result = $this->storedCards->getFormattedInstallments();
+
+        $this->assertIsString($result);
+        $this->assertEquals($mockInstalments, $result);
+    }
+
+    public function testPlaceOrderSuccess()
+    {
+        $data = [
+            ProcessingMetadataInterface::POST_KEY_PUBLIC_HASH => 'mock_public_hash',
+            'stateData' => [],
+            'extension_attributes' => [
+                'agreement_id' => ['1', '2']
+            ]
+        ];
+        $paymentStatus = 'success';
+        $quoteId = '111';
+        $orderId = '123';
+
+        $this->setPlaceOrderCommonExpectations($quoteId);
+
+        $this->paymentInformationManagementMock->expects($this->once())
+            ->method('savePaymentInformationAndPlaceOrder')
+            ->with($quoteId, $this->paymentMock)
+            ->willReturn($orderId);
+
+        $this->adyenOrderPaymentStatusMock->expects($this->once())
+            ->method('getOrderPaymentStatus')
+            ->with($orderId)
+            ->willReturn($paymentStatus);
+
+        $this->storedCards->placeOrder($data);
+
+        $this->assertEquals($paymentStatus, $this->storedCards->paymentStatus);
+    }
+
+    private function setPlaceOrderCommonExpectations($quoteId)
+    {
+        $this->sessionMock->expects($this->once())
+            ->method('getQuoteId')
+            ->willReturn($quoteId);
+
+        $this->sessionMock->expects($this->exactly(2))
+            ->method('getQuote')
+            ->willReturn($this->quoteMock);
+
+        $this->quoteMock->expects($this->exactly(2))
+            ->method('getPayment')
+            ->willReturn($this->paymentMock);
+
+        $this->paymentExtensionFactoryMock
+            ->method('create')
+            ->willReturn($this->paymentExtensionMock);
+    }
+}

--- a/view/frontend/templates/payment/method-renderer/adyen-amazonpay-method.phtml
+++ b/view/frontend/templates/payment/method-renderer/adyen-amazonpay-method.phtml
@@ -130,11 +130,18 @@ use Magento\Framework\View\Element\Template;
             placeOrder(data, publicHash = null, amazonPayComponent) {
                 let self = this;
                 let wire = self.wire;
+                let extensionAttributes = {};
+                const termsAndConditionIds = Object.keys(Magewire.find('checkout.terms-conditions').get('termAcceptance'));
+
+                if (termsAndConditionIds.length > 0) {
+                    extensionAttributes.agreement_ids = termsAndConditionIds;
+                }
 
                 wire.placeOrder({
                     stateData: data,
                     ccType: this.getCreditCardType(),
-                    publicHash: publicHash
+                    publicHash: publicHash,
+                    extension_attributes: extensionAttributes
                 })
                     .then(() => {
                         let paymentStatus = JSON.parse(wire.get('paymentStatus'));

--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -347,11 +347,18 @@ $billingAddress = $block->getQuoteBillingAddress();
             window.dispatchEvent(new Event('magewire:loader:start'));
             let self = this;
             let wire = self.wire;
+            let extensionAttributes = {};
+            const termsAndConditionIds = Object.keys(Magewire.find('checkout.terms-conditions').get('termAcceptance'));
+
+            if (termsAndConditionIds.length > 0) {
+                extensionAttributes.agreement_ids = termsAndConditionIds;
+            }
 
             wire.placeOrder({
                 stateData: data,
                 ccType: this.getCreditCardType(),
-                publicHash: publicHash
+                publicHash: publicHash,
+                extension_attributes: extensionAttributes
             })
                 .then(() => {
                     let paymentStatus = JSON.parse(wire.get('paymentStatus'));


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
It has been observed that the module couldn't place any order if Terms & Conditions is enabled on the checkout as the required extension attributes were not passed to Magewire from the frontend. This PR implements the agreements acceptor as a part of extension attributes while placing order.

## Tested scenarios
<!-- Description of tested scenarios -->
- Placing order with card and Ideal payment methods while T&C is enabled/disabled.
- Unit tests have been updated.

Fixes #70 