### PR TITLE
Fix main github workflow checkout ref

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Use PHP ${{ matrix.php-version }}


### PR DESCRIPTION
Possibly fix Main github workflow checkout ref.
This ref is the same setup as: https://github.com/Adyen/adyen-magento2/blob/main/.github/workflows/main.yml#L21