### PR TITLE
[ECP-9627] Fix order placement if terms & conditions is disabled

### DIFF
--- a/view/frontend/templates/payment/method-renderer/adyen-amazonpay-method.phtml
+++ b/view/frontend/templates/payment/method-renderer/adyen-amazonpay-method.phtml
@@ -131,10 +131,13 @@ use Magento\Framework\View\Element\Template;
                 let self = this;
                 let wire = self.wire;
                 let extensionAttributes = {};
-                const termsAndConditionIds = Object.keys(Magewire.find('checkout.terms-conditions').get('termAcceptance'));
 
-                if (termsAndConditionIds.length > 0) {
-                    extensionAttributes.agreement_ids = termsAndConditionIds;
+                if (document.querySelectorAll('[wire\\:id="checkout.terms-conditions"]').length) {
+                    const termsAndConditionIds = Object.keys(Magewire.find('checkout.terms-conditions').get('termAcceptance'));
+
+                    if (termsAndConditionIds.length > 0) {
+                        extensionAttributes.agreement_ids = termsAndConditionIds;
+                    }
                 }
 
                 wire.placeOrder({

--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -348,10 +348,13 @@ $billingAddress = $block->getQuoteBillingAddress();
             let self = this;
             let wire = self.wire;
             let extensionAttributes = {};
-            const termsAndConditionIds = Object.keys(Magewire.find('checkout.terms-conditions').get('termAcceptance'));
 
-            if (termsAndConditionIds.length > 0) {
-                extensionAttributes.agreement_ids = termsAndConditionIds;
+            if (document.querySelectorAll('[wire\\:id="checkout.terms-conditions"]').length) {
+                const termsAndConditionIds = Object.keys(Magewire.find('checkout.terms-conditions').get('termAcceptance'));
+
+                if (termsAndConditionIds.length > 0) {
+                    extensionAttributes.agreement_ids = termsAndConditionIds;
+                }
             }
 
             wire.placeOrder({


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->
Magewire doesn't return `null` anymore if the component is not attached to the frontend while using `Magewire.find()` command. Instead, it returns `Uncaught TypeError: Cannot read properties of undefined (reading '$wire')` as explained [here](https://docs.hyva.io/checkout/hyva-checkout/magewire/vanilla-js.html).

Due to this change, the terms and conditions acceptor implementation fails. To this this issue, the module started to check the existence of the component before accessing a property of it

## Tested scenarios
<!-- Description of tested scenarios -->
- Placing order while terms & conditions enabled/disabled