### PR TITLE
Fix missing CC form in checkout

### DIFF
--- a/view/frontend/templates/payment/model/adyen-payment-method.phtml
+++ b/view/frontend/templates/payment/model/adyen-payment-method.phtml
@@ -316,7 +316,9 @@ $billingAddress = $block->getQuoteBillingAddress();
                 countryCode: formattedShippingAddress.country_id ? formattedShippingAddress.country_id : formattedBillingAddress.country_id
             };
 
-            if (!!paymentMethodsExtraInfo[paymentMethod.type].configuration) {
+            if (paymentMethodsExtraInfo &&
+                paymentMethodsExtraInfo[paymentMethod.type] &&
+                paymentMethodsExtraInfo[paymentMethod.type].configuration) {
                 return Object.assign(configuration, paymentMethodsExtraInfo[paymentMethod.type].configuration)
             } else {
                 return configuration;


### PR DESCRIPTION
When selecting Adyen Credit Card as the payment method in the Hyvä Checkout, the input form for card details (card number, expiry date, etc.) is not displayed.
Instead, a JavaScript error appears in the browser console, rendering the payment method unusable.

**Steps to Reproduce**
	1.	Go to the checkout page with Hyvä Checkout enabled
	2.	Ensure Adyen Credit Card is available as a payment method
	3.	Select Credit Card (Adyen)
	4.	❌ Expected: Form fields for card number, expiry date, etc. appear
	5.	❌ Actual: No form is shown; a JavaScript error appears in the browser console